### PR TITLE
Drone CI setup with publish docker image to ghcr

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,4 +36,6 @@ steps:
 
 ---
 kind: signature
-hmac: 13d584e973017ab053c389c87d797deb78ea0c85c348446c7e5c1e3e8a174bc3
+hmac: 8b78559987b3213bc139f7f299ce74e46967fd3a1d7386c264e6c403ccda03ca
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,10 +32,9 @@ steps:
           - pull_request
       branch:
         - main
-        - feat/drone-ci-setup
 
 ---
 kind: signature
-hmac: 8b78559987b3213bc139f7f299ce74e46967fd3a1d7386c264e6c403ccda03ca
+hmac: af032206e6fe57ddf4bee365bc616c3d8936973e0aa51e162a662f8026848422
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,39 @@
+---
+kind: pipeline
+type: docker
+name: Build and publish
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: build
+    image: golang
+    commands:
+      - make build
+
+  - name: Build and publish docker image
+    image: plugins/docker
+    settings:
+      registry: ghcr.io
+      repo: ghcr.io/kevinmidboe/planetposen-images
+      dockerfile: Dockerfile
+      username:
+        from_secret: GITHUB_USERNAME
+      password:
+        from_secret: GITHUB_PASSWORD
+      tags: latest
+    when:
+      event:
+        include:
+          - push
+        exclude:
+          - pull_request
+      branch:
+        - main
+        - feat/drone-ci-setup
+
+---
+kind: signature
+hmac: 13d584e973017ab053c389c87d797deb78ea0c85c348446c7e5c1e3e8a174bc3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Build the project
+FROM golang:1.19 as builder
+
+LABEL org.opencontainers.image.source="https://github.com/KevinMidboe/planetposen-images"
+
+WORKDIR /go/src/github.com/kevinmidboe/planetposen-images
+ADD . .
+
+RUN make build
+# RUN make test
+
+# Create production image for application with needed files
+FROM golang:1.19-alpine
+
+EXPOSE 8000
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /go/src/github.com/kevinmidboe/planetposen-images .
+
+CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -33,4 +33,3 @@ or
 ```bash
 (sudo) docker run -d --name planetposen-images -p 8000:8000 --env-file .env planetposen-images
 ```
-


### PR DESCRIPTION
- Setup Dockerfile
- Drone config for build & publish to github container registry (ghcr)